### PR TITLE
Add case to message interface to handle showing reference window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,7 @@ docs/template/nmdc_dh/schema.js: clean artifacts/nmdc_dh.yaml
 	cd DataHarmonizer/template/nmdc_dh ; poetry run python ../../script/linkml.py --input source/nmdc_dh.yaml
 	cp -r DataHarmonizer/linkml.html DataHarmonizer/linkml.js DataHarmonizer/main.css DataHarmonizer/libraries DataHarmonizer/script DataHarmonizer/template docs
 	cp artifacts/for_data_harmonizer_scripts/linkml.js docs
-	# remove once https://github.com/cidgoh/DataHarmonizer/pull/299 is merged
-	wget -O docs/script/data-harmonizer/index.js https://raw.githubusercontent.com/pkalita-lbl/DataHarmonizer/min-max-guidance/script/data-harmonizer/index.js
-
+	
 # https://gist.github.com/steinwaywhw/a4cd19cda655b8249d908261a62687f8
 # https://stackoverflow.com/questions/10121182/multi-line-bash-commands-in-makefile
 # https://stackoverflow.com/questions/1078524/how-to-specify-the-download-location-with-wget

--- a/artifacts/for_data_harmonizer_scripts/linkml.js
+++ b/artifacts/for_data_harmonizer_scripts/linkml.js
@@ -97,6 +97,10 @@ const setupMessageInterface = (dh) => {
                     dh.hot.loadData(event.data.data);
                     break;
 
+                case 'showReference':
+                    dh.renderReference();
+                    break;
+
                 default:
                     console.log('Unknown Type', event.data.type);
             }
@@ -121,7 +125,7 @@ $(document).ready(async () => {
 	$(myDHToolbar).append($('#data-harmonizer-toolbar-inset'));
 	$('#data-harmonizer-toolbar-inset').css('visibility','visible');
 
-	// Note: TEMPLATES contains templates/menu.js object. It is only required 
+	// Note: TEMPLATES contains templates/menu.js object. It is only required
 	// if using dh.getTemplate() below without specifying a template.
 	await dh.init(myDHGrid, myDHFooter, TEMPLATES);
 
@@ -131,7 +135,7 @@ $(document).ready(async () => {
 	let template_path = dh.getTemplate();
 	// Hardcode URL here if desired. Expecting a file path relative to app's template folder.
 	await dh.useTemplate(template_path)
-	
+
     await toolbar.refresh();
 
     dh.updateParentState();


### PR DESCRIPTION
This will be the interface that the NDMC portal can use to open the Reference Guide window instead of linking to a static HTML file.

Note that this will not work until the `DataHarmonizer` submodule is updated to the latest `linkmk-datastructure` version, and I would hold off on that until https://github.com/cidgoh/DataHarmonizer/pull/304 is merged.