### PR TITLE
Attempt to preserve numeric types when handling attribute replacements

### DIFF
--- a/sheets_and_friends/modifications_and_validation.py
+++ b/sheets_and_friends/modifications_and_validation.py
@@ -134,6 +134,15 @@ def replace_attribute_handler(schema_dict, base_path, target, value):
                     fiddled_value = False
                 else:
                     logger.warning(f"While setting ${full_target}, boolean value not recognized: {value}")
+            else:
+                # Attempt to preserve the original type of the value
+                try:
+                    fiddled_value = int(value)
+                except ValueError:
+                    try:
+                        fiddled_value = float(value)
+                    except ValueError:
+                        fiddled_value = value
             glom(schema_dict, Assign(full_target, fiddled_value))
         else:
             # If this is not the last element of the target path, we need to ensure that the


### PR DESCRIPTION
This came up while building the `submission-schema` off of `nmdc-schema` v11.0.0. The chain of causes was:

1. Handling `nmdc-schema` v11.0.0 requires a `linkml-runtime` dependency that includes the necessary metamodel changes for structured aliases.
2. The necessary version of the metamodel _also_ includes changes that update the range of `minimum_value` and `maximum_value` on `SlotDefinition` to `Any` -- previously it was `int`.
3. When `sheets_and_friends` reads a modification spreadsheet the `value` column is read as strings, and so the output it produces might look something like:
   ```yaml
   minimum_value: '0'
   ```
4. The `submission-schema` Makefile would feed that output through `gen-linkml`. Because of the `int` range and the `@dataclass` behavior of attempting to coerce values, the output of `gen-linkml` was:
   ```yaml
   minimum_value: 0
   ```
5. However, with the change to have an `Any` range, no coercion is done. So the output of `gen-linkml` becomes the same what's listed in 3.

These changes make it so that the output at step 3 above becomes
```yaml
minimum_value: 0
```
Then the lack of coercion by `gen-linkml` is a non-issue.

cc: @turbomam 